### PR TITLE
add cookbook

### DIFF
--- a/get-started/deploying-on-metis.md
+++ b/get-started/deploying-on-metis.md
@@ -1,5 +1,9 @@
 # Deploying on Metis
 
+### Using Cookbook.dev <a href="#cookbookdev" id="cookbookdev"></a>
+
+Cookbook is the easiest way for web3 developers to [find](https://www.cookbook.dev/search?q=&sort=popular&filter=&page=1) documented smart contracts, solidity libraries, and discover protocols. Deploy with a single click, or easily integrate with ChainIDE, Remix, Hardhat, Foundry or any other Solidity tool!
+
 ### Using the ThirdWeb framework <a href="#_jrhnn8um2jms" id="_jrhnn8um2jms"></a>
 
 ThirdWeb [provides](https://thirdweb.com/explore) a great set of tools for web3 developers to explore smart contracts from world-class web3 protocols & engineers — all deployable with one click.


### PR DESCRIPTION
Cookbook was added as a Metis CVP quite a while ago - figure it's finally time to be added to the docs! 

Starting simple with this PR, but would love to add a more detailed walkthrough as a standalone page at some point. Maybe thinking something like what we have in the Gnosis docs: https://docs.gnosischain.com/developers/smart-contracts/cookbook

Thanks!