### PR TITLE
data indexers category added to developer tools; PARSIQ added there

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,19 @@ Read more on [Nodes](protocol-in-detail/)
 
 
 
+#### Metis Data Indexers <a href="#_h1ka8epzf8qo" id="_h1ka8epzf8qo"></a>
+
+Data indexers are third-party services that provide APIs and SDKs for raw and processed blockchain data on transactions, dApp-specific data, as well as additional offchain data such as token prices  on Metis chain.
+
+Read more on [Data Indexers](tools/data-indexers/)
+
+
+
 #### Metis SubGraph <a href="#_s7n3z5vmr8nt" id="_s7n3z5vmr8nt"></a>
 
 The Metis SubGraph is an indexing protocol for collecting, processing, and storing data to be used in the blockchain network. It aims at facilitating information retrieval using a service called GraphQL.
 
-Read more on[ What is a Metis SubGraph](tools/the-subgraph.md)
+Read more on [What is a Metis SubGraph](tools/the-subgraph.md)
 
 
 

--- a/tools/data-indexers/README.md
+++ b/tools/data-indexers/README.md
@@ -1,0 +1,7 @@
+# Data Indexers
+
+Data indexers are third-party services that provide APIs and SDKs for raw and processed blockchain data on transactions, smart contract function calls and events, FT and NFT transfers, dApp-specific data, as well as additional offchain data such as token prices on Metis chain. The data they provide might be useful for dApp dashboards, analytics, user notifications, etc.
+
+| Tool     | Use-cases                                                                            | Relevant links                                                                                                                                                                                                                                 |
+| -------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PARSIQ | Allows for tracking any blockchain activity on Metis network historically and in real-time, as well as building dApp-specific APIs using SDK | <ul><li>[API Reference](https://docs.parsiq.net/reference/introduction)</li><li>[SDK&nbsp;Documentation](https://docs.parsiq.net/reference/your-own-web3-api)</li></ul> |


### PR DESCRIPTION
Data indexers category added to developer tools. PARSIQ data indexer added there.
**Important**: I did not find how to correctly get an href/id in core README.md. I just generated a random one. Hope this does not break anything.

![image](https://github.com/Metis-DAO/Metis/assets/7903312/85a7e7b9-0033-4b86-9fe4-71207141a75f)
